### PR TITLE
Add GitHub Skills activity to the system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the GitHub Skills activity that was announced by the principal and reported as missing in issue #6.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Activity details:
  - Description: Learn practical coding and collaboration skills with GitHub (part of GitHub Certifications program)
  - Schedule: Wednesdays, 3:30 PM - 4:30 PM
  - Max participants: 25 students
  - Currently 0 participants (ready for student signups)

## Related Issue
Closes #6

## Testing
The activity will now appear in the activities list and students can sign up before the end-of-week deadline.